### PR TITLE
Adding bound check for PrivateKey init from data + cleanup

### DIFF
--- a/BitcoinKit.xcodeproj/project.pbxproj
+++ b/BitcoinKit.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 		29F5D1E02110495F007DA3BF /* OpCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29F5D1DF2110495F007DA3BF /* OpCodeTests.swift */; };
 		29F5D1E421106772007DA3BF /* BigNumberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29F5D1E321106772007DA3BF /* BigNumberTests.swift */; };
 		29F5D1E6211068E8007DA3BF /* BigNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29F5D1E5211068E8007DA3BF /* BigNumber.swift */; };
+		48022C72233366E8004F9021 /* Curve+Secp256k1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48022C71233366E8004F9021 /* Curve+Secp256k1.swift */; };
 		481BDCA423320B7000FC79FC /* WordList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481BDC9823320B7000FC79FC /* WordList.swift */; };
 		481BDCA523320B7000FC79FC /* WordList+Japanese.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481BDC9923320B7000FC79FC /* WordList+Japanese.swift */; };
 		481BDCA623320B7000FC79FC /* WordList+English.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481BDC9A23320B7000FC79FC /* WordList+English.swift */; };
@@ -460,6 +461,7 @@
 		29F5D1DF2110495F007DA3BF /* OpCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpCodeTests.swift; sourceTree = "<group>"; };
 		29F5D1E321106772007DA3BF /* BigNumberTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BigNumberTests.swift; sourceTree = "<group>"; };
 		29F5D1E5211068E8007DA3BF /* BigNumber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BigNumber.swift; sourceTree = "<group>"; };
+		48022C71233366E8004F9021 /* Curve+Secp256k1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Curve+Secp256k1.swift"; sourceTree = "<group>"; };
 		481BDC9823320B7000FC79FC /* WordList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordList.swift; sourceTree = "<group>"; };
 		481BDC9923320B7000FC79FC /* WordList+Japanese.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WordList+Japanese.swift"; sourceTree = "<group>"; };
 		481BDC9A23320B7000FC79FC /* WordList+English.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WordList+English.swift"; sourceTree = "<group>"; };
@@ -686,6 +688,7 @@
 		292AEA3C2112EB190012D7E5 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				48022C70233366CE004F9021 /* EllipticCurve */,
 				481BDCC52332172C00FC79FC /* SecureGenerateBytes */,
 				481BDC9623320B7000FC79FC /* Mnemonic */,
 				29AC9962214E898800AE82FE /* Keys */,
@@ -1020,6 +1023,14 @@
 			path = Keys;
 			sourceTree = "<group>";
 		};
+		48022C70233366CE004F9021 /* EllipticCurve */ = {
+			isa = PBXGroup;
+			children = (
+				48022C71233366E8004F9021 /* Curve+Secp256k1.swift */,
+			);
+			path = EllipticCurve;
+			sourceTree = "<group>";
+		};
 		481BDC9623320B7000FC79FC /* Mnemonic */ = {
 			isa = PBXGroup;
 			children = (
@@ -1255,6 +1266,7 @@
 				14839AA3202FE78600A6CB34 /* Message.swift in Sources */,
 				29290B95210AF86C00D2BE78 /* OP_N.swift in Sources */,
 				0C1DE171211E7DE300FE8E43 /* OP_2OVER.swift in Sources */,
+				48022C72233366E8004F9021 /* Curve+Secp256k1.swift in Sources */,
 				29290BA5210AFD7A00D2BE78 /* OP_PUSHDATA.swift in Sources */,
 				297DB97520EB13320077EEEE /* AddressFactory.swift in Sources */,
 				0C1DE180211EACE800FE8E43 /* OP_NUM2BIN.swift in Sources */,

--- a/Sources/BitcoinKit/Core/EllipticCurve/Curve+Secp256k1.swift
+++ b/Sources/BitcoinKit/Core/EllipticCurve/Curve+Secp256k1.swift
@@ -1,0 +1,40 @@
+//
+//  Curve+Secp256k1.swift
+// 
+//  Copyright © 2019 BitcoinKit developers
+//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//  
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//  
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+public enum Curve {}
+public extension Curve {
+	enum Secp256k1 {}
+}
+
+public extension Curve.Secp256k1 {
+	/// `fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141`
+	static let order = Data([
+		0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+		0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE,
+		0xBA, 0xAE, 0xDC, 0xE6, 0xAF, 0x48, 0xA0, 0x3B,
+		0xBF, 0xD2, 0x5E, 0x8C, 0xD0, 0x36, 0x41, 0x41
+	])
+}

--- a/Sources/BitcoinKit/Core/Keys/HDPrivateKey.swift
+++ b/Sources/BitcoinKit/Core/Keys/HDPrivateKey.swift
@@ -78,7 +78,11 @@ public class HDPrivateKey {
     }
 
     public func privateKey() -> PrivateKey {
-        return PrivateKey(data: raw, network: network, isPublicKeyCompressed: true)
+        do {
+            return try PrivateKey(data: raw, network: network, shouldCompressPublicKey: true)
+        } catch {
+            fatalError("Unexpected error: \(error), should always be possible to create `PrivateKey` from `HDPrivateKey`")
+        }
     }
 
     public func extendedPublicKey() -> HDPublicKey {

--- a/Tests/BitcoinKitTests/Core/CryptoTests.swift
+++ b/Tests/BitcoinKitTests/Core/CryptoTests.swift
@@ -45,7 +45,7 @@ class CryptoTests: XCTestCase {
     func testSign() {
         let msg = Data(hex: "52204d20fd0131ae1afd173fd80a3a746d2dcc0cddced8c9dc3d61cc7ab6e966")!
         let pk = Data(hex: "16f243e962c59e71e54189e67e66cf2440a1334514c09c00ddcc21632bac9808")!
-        let privateKey = PrivateKey(data: pk)
+        let privateKey = try! PrivateKey(data: pk)
 
         let signature = try? Crypto.sign(msg, privateKey: privateKey)
 


### PR DESCRIPTION
Adding bound check for PrivateKey init from data, also doing a bit of a clean up and adding tests.

### Description of the Change

Prior to this PR the initializer of a `PrivateKey` did *NOT* validate the value of the scalar (represented as `Data`), to check if it was within bounds. This check was only done when generating a new key.

Generating PrivateKey entropy using the cleaned up `securelyGenerateBytes`  introduced in [commit 7fb919b](https://github.com/yenom/BitcoinKit/blob/7fb919b1d3ae43849111e37c89e07d70bdb2f9e7/Sources/BitcoinKit/Core/SecureGenerateBytes/SecureGenerateBytes.swift), also more clear what bounds are used and why, by introducing mini type `Secp256k1` and displaying order of that curve.

I also changed the named of the bool indicating whether or not the public key should be compressed or not. 

I also added some documentation.

### Alternate Designs

The initializer could be made failing `init?` instead of throwing, but that way we do not get info about what was wrong. One can always change `try` to `try?` to make a throwing init into a failing one instead.

### Benefits

Safer and clearer init of `PrivateKey`.

### Possible Drawbacks

Some people do not lack safe code which requires you to do `try`, but hey, Swift is meant to be a safe language thus should a great SDK also be made safe in my opinion :). Safe as in avoiding runtime crashes due to in this case a PrivateKey having values out of bounds, which allows for lots of strange errors when signing (you cannot sign anything using a key being larger than the order of the curve....)

### Applicable Issues

Some people need to add handling of new throwing init, but I think most people where using HDWallet, so they are unaffected.
