### PR TITLE
feat(utils): add NetworkStatusChecker for Bitcoin node connectivity check

### DIFF
--- a/Sources/Utils/NetworkStatusChecker.swift
+++ b/Sources/Utils/NetworkStatusChecker.swift
@@ -1,0 +1,49 @@
+//
+//  NetworkStatusChecker.swift
+//  BitcoinKit
+//
+//  Created by Marta on 18/10/2025.
+//  Distributed under the MIT License.
+//
+
+import Foundation
+
+/// Educational example for GitHub workflow practice.
+/// Checks basic reachability to a Bitcoin node endpoint.
+/// Not for production use.
+public final class NetworkStatusChecker {
+
+    public enum NetworkError: Error {
+        case invalidURL
+        case noResponse
+        case unreachable
+    }
+
+    public init() {}
+
+    /// Attempts to ping the given Bitcoin node (or API endpoint) with a simple request.
+    /// - Parameter endpoint: Node URL (e.g. "https://blockchain.info")
+    /// - Returns: Boolean indicating connectivity.
+    @discardableResult
+    public func isNodeReachable(endpoint: String) async throws -> Bool {
+        guard let url = URL(string: endpoint) else {
+            throw NetworkError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "HEAD"
+        request.timeoutInterval = 5
+
+        let (_, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NetworkError.noResponse
+        }
+
+        if (200...399).contains(httpResponse.statusCode) {
+            return true
+        } else {
+            throw NetworkError.unreachable
+        }
+    }
+}


### PR DESCRIPTION
### Summary
This PR adds a new utility class `NetworkStatusChecker` to `Sources/Utils/`.
It provides a simple async function to test connectivity to a Bitcoin node or API endpoint.

### Motivation
While developing wallet features or testing network operations, developers often need to verify if a node or blockchain API is reachable. This helper offers a lightweight way to do so.

### Implementation
- Uses Swift concurrency (`async/await`)
- Simple `HEAD` request for speed and safety
- Provides detailed error cases for invalid URL, timeout, or unreachable host

### Example usage
```swift
let checker = NetworkStatusChecker()
Task {
    do {
        let reachable = try await checker.isNodeReachable(endpoint: "https://blockchain.info")
        print("✅ Reachable:", reachable)
    } catch {
        print("❌ Error:", error)
    }
}

