### PR TITLE
Add simple version info utility

### DIFF
--- a/Sources/Utils/BitcoinKitVersion.swift
+++ b/Sources/Utils/BitcoinKitVersion.swift
@@ -1,0 +1,17 @@
+//
+//  BitcoinKitVersion.swift
+//  BitcoinKit
+//
+//  Created by Contributor on 2025/10/18.
+//
+
+import Foundation
+
+/// Prints the current version of BitcoinKit framework.
+public struct BitcoinKitVersion {
+    public static let version = "1.1.0"
+
+    public static func printVersion() {
+        print("BitcoinKit version: \(version)")
+    }
+}


### PR DESCRIPTION

Added a new utility file BitcoinKitVersion.swift under Sources/Utils/.
This struct provides a lightweight method to print the current BitcoinKit version at runtime, which can be useful for debugging, logs, and dependency validation in apps using the framework.

No external dependencies were added.