### PR TITLE
Add demo VersionHelper for local testing

### DIFF
--- a/Sources/Utils/VersionHelper.swift
+++ b/Sources/Utils/VersionHelper.swift
@@ -1,0 +1,10 @@
+// Example only — do not submit upstream
+import Foundation
+
+/// Simple helper to print the current BitcoinKit version.
+/// Intended for testing and local builds.
+public struct VersionHelper {
+    public static func printVersion() {
+        print("BitcoinKit - Demo Build 1.1.1")
+    }
+}


### PR DESCRIPTION
Description:
This pull request adds a simple helper struct VersionHelper that prints the current BitcoinKit version to the console.
It is designed as a local utility for testing build environments and demo purposes only.

Changes:

Added Sources/Utils/VersionHelper.swift

Updated no production logic