### PR TITLE
add lightweight NetworkInfo utility for environment detection

### DIFF
--- a/Sources/Utils/NetworkInfo.swift
+++ b/Sources/Utils/NetworkInfo.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Simple utility to detect current Bitcoin network (mainnet or testnet)
+public enum NetworkInfo {
+    public static var isTestnet: Bool {
+        #if DEBUG
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    public static var networkName: String {
+        return isTestnet ? "testnet" : "mainnet"
+    }
+}


### PR DESCRIPTION
This pull request adds a small Swift utility to help determine the current
network environment (mainnet or testnet) based on build configuration.

- New file: Sources/Utils/NetworkInfo.swift
- Provides `isTestnet` and `networkName` helpers
- Useful for debugging and environment-specific UI labels


