### PR TITLE
dd Swift example for HD wallet generation and first address derivation

### DIFF
--- a/Examples/GenerateNewWalletExample.swift
+++ b/Examples/GenerateNewWalletExample.swift
@@ -1,0 +1,35 @@
+//
+//  GenerateNewWalletExample.swift
+//  BitcoinKit
+//
+//  Created by Contributor on 2025-11-01.
+//
+
+import Foundation
+import BitcoinKit
+
+/// Simple example showing how to create a new HD wallet and print its first receiving address.
+struct GenerateNewWalletExample {
+
+    static func run() {
+        // Generate a new random mnemonic phrase (BIP39)
+        let mnemonic = Mnemonic.generate()
+        print("Generated mnemonic:")
+        print(mnemonic.joined(separator: " "))
+
+        // Create seed from mnemonic
+        let seed = Mnemonic.seed(mnemonic: mnemonic)
+        let wallet = HDWallet(seed: seed, network: .mainnetBTC)
+
+        // Derive the first external receiving address (m/44'/0'/0'/0/0)
+        let privateKey = try! wallet.privateKey(index: 0, chain: .external)
+        let publicKey = privateKey.publicKey()
+        let address = publicKey.toLegacy()
+
+        print("First receiving address:")
+        print(address)
+    }
+}
+
+// Run example
+GenerateNewWalletExample.run()


### PR DESCRIPTION

### What
Introduces a new example `GenerateNewWalletExample.swift` under `/Examples/`
that demonstrates how to create a new BIP39 mnemonic, derive an HD wallet,
and print the first receiving address.

### Why
BitcoinKit provides powerful wallet tools (BIP32/BIP39/BIP44) but currently
lacks a simple usage example in Swift. This addition helps new developers
understand the basic workflow for wallet generation.

### Files Added
- `Examples/GenerateNewWalletExample.swift`

### Example Usage
Run in Xcode or Swift REPL:
```swift
GenerateNewWalletExample.run()
